### PR TITLE
Prevent two AttributeErrors when selecting object without pose lib/armature.

### DIFF
--- a/pose_lib_previews.py
+++ b/pose_lib_previews.py
@@ -24,7 +24,7 @@ preview_collections = {}
 def generate_previews(self, context):
     enum_items = []
 
-    if context is None:
+    if context is None or not self.pose_library:
         return enum_items
 
     obj = self
@@ -95,7 +95,7 @@ def generate_previews(self, context):
 def get_pose_bone_groups(self, context):
     enum_items = []
 
-    if context is None:
+    if context is None or not self.pose:
         return enum_items
 
     obj = self


### PR DESCRIPTION
Prevents those two tracebacks:

```
Traceback (most recent call last):
  File "/home/sybren/.config/blender/2.77/scripts/addons/pose_lib_preview/pose_lib_previews.py", line 104, in get_pose_bone_groups
    bone_groups = obj.pose.bone_groups
AttributeError: 'NoneType' object has no attribute 'bone_groups'
```

```
Traceback (most recent call last):
  File "/home/sybren/.config/blender/2.77/scripts/addons/pose_lib_preview/pose_lib_previews.py", line 33, in generate_previews
    directory = pose_lib.pose_previews_dir
AttributeError: 'NoneType' object has no attribute 'pose_previews_dir'
File "/home/sybren/.config/blender/2.77/scripts/addons/pose_lib_preview/pose_lib_previews.py", line 25, in generate_previews
```
