### PR TITLE
Some more improvements

### DIFF
--- a/pose_thumbnails.py
+++ b/pose_thumbnails.py
@@ -623,6 +623,17 @@ class POSELIB_PT_pose_previews(bpy.types.Panel):
             )
 
 
+class POSELIB_OT_help_regexp(bpy.types.Operator):
+    """Open Regular Expression explanation in a webbrowser"""
+    bl_label = 'Help'
+    bl_idname = 'poselib.help_regexp'
+
+    def execute(self, context):
+        import webbrowser
+        webbrowser.open_new_tab('https://en.wikipedia.org/wiki/Regular_expression')
+        return {'FINISHED'}
+
+
 def register():
     """Register all pose thumbnail related things."""
     bpy.types.WindowManager.pose_mix_factor = bpy.props.FloatProperty(

--- a/pose_thumbnails.py
+++ b/pose_thumbnails.py
@@ -573,7 +573,7 @@ class PoselibUiSettings(bpy.types.PropertyGroup):
 class POSELIB_PT_pose_previews(bpy.types.Panel):
     """Creates a pose thumbnail panel in the 3D View Properties panel"""
     bl_label = "Pose Library"
-    bl_idname = "POSELIB_PT_pose_previews"
+    bl_idname = "poselib.pose_previews"
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'UI'
     bl_context = "data"

--- a/pose_thumbnails.py
+++ b/pose_thumbnails.py
@@ -160,7 +160,10 @@ def flip_selection():
         for pb in pose_bones
     }
     for name, select in selections.items():
-        pose_bones[name].bone.select = select
+        try:
+            pose_bones[name].bone.select = select
+        except KeyError:
+            pass  # this happens when a bone exists only on one side
 
 
 def select_all_pose_bones(armature, deselect=False):

--- a/pose_thumbnails.py
+++ b/pose_thumbnails.py
@@ -265,17 +265,22 @@ def pose_library_name_prefix(ob_name: str, context) -> str:
     """Determine the pose library prefix name for the given object name.
 
     >>> pose_library_name_prefix('Sintel-heavy-haired')
-    'PLB_Sintel'
+    'PLB-Sintel'
     >>> pose_library_name_prefix('spring_blenrig')
-    'PLB_spring_blenrig'
+    'PLB-spring_blenrig'
     >>> pose_library_name_prefix('Spring-blenrig')
-    'PLB_Spring'
+    'PLB-Spring'
+    >>> pose_library_name_prefix('RIG-Spring.high_proxy')
+    'PLB-Spring'
     """
+    addon_prefs = prefs.for_addon(context)
+    if ob_name.startswith(addon_prefs.optional_name_prefix):
+        ob_name = ob_name[len(addon_prefs.optional_name_prefix):]
+
     char_name = character_name(ob_name, context)
     if not char_name:
         return ''
 
-    addon_prefs = prefs.for_addon(context)
     return addon_prefs.pose_lib_name_prefix + char_name
 
 

--- a/prefs.py
+++ b/prefs.py
@@ -37,6 +37,12 @@ class PoseThumbnailsPreferences(bpy.types.AddonPreferences):
         default='[A-Za-z0-9_]+',
         update=clear_charnamere_cache,
     )
+    optional_name_prefix = bpy.props.StringProperty(
+        name='Optional Object Prefix',
+        description='Strip this off the object name before determining the Character Name. '
+                    'Ignored if the object name does not start with this',
+        default='RIG-',
+    )
     pose_lib_name_prefix = bpy.props.StringProperty(
         name='Pose Library Name Prefix',
         description='Only Actions whose name start with this prefix are considered Pose Libraries',
@@ -60,6 +66,8 @@ class PoseThumbnailsPreferences(bpy.types.AddonPreferences):
         col = layout.box()
         col.label('Character Name and Pose Library recognition:', icon='TRIA_RIGHT')
         col.prop(self, 'character_name_regexp')
+        col = col.column(align=True)
+        col.prop(self, 'optional_name_prefix')
         col.prop(self, 'pose_lib_name_prefix')
         try:
             re.compile(self.character_name_regexp)
@@ -68,6 +76,6 @@ class PoseThumbnailsPreferences(bpy.types.AddonPreferences):
                       icon='ERROR')
         else:
             from . import pose_thumbnails
-            char = 'Alpha_monster-blenrig.001'
+            char = self.optional_name_prefix + 'Alpha_monster-blenrig.001'
             pl = pose_thumbnails.pose_library_name_prefix(char, context)
             col.label('Object %r will use Pose Libraries %r' % (char, pl + '…'))

--- a/prefs.py
+++ b/prefs.py
@@ -33,7 +33,7 @@ class PoseThumbnailsPreferences(bpy.types.AddonPreferences):
     )
     character_name_regexp = bpy.props.StringProperty(
         name='Character Name Regexp',
-        description='Regular Expression that obtains the character name from the object name',
+        description='Obtains the character name from the object name',
         default='[A-Za-z0-9_]+',
         update=clear_charnamere_cache,
     )
@@ -65,7 +65,10 @@ class PoseThumbnailsPreferences(bpy.types.AddonPreferences):
         layout.separator()
         col = layout.box()
         col.label('Character Name and Pose Library recognition:', icon='TRIA_RIGHT')
-        col.prop(self, 'character_name_regexp')
+        row = col.row(align=True)
+        row.prop(self, 'character_name_regexp')
+        row.operator('poselib.help_regexp', icon='HELP', text='')
+
         col = col.column(align=True)
         col.prop(self, 'optional_name_prefix')
         col.prop(self, 'pose_lib_name_prefix')


### PR DESCRIPTION
Few small things:

- Introduced an optional object name prefix, so that both `RIG-Spring-blenrig` and `Spring-blenrig` are both recognised as the character "Spring". This allows us to work with pose libraries both in the original rig file (where the armature object is called `RIG-Spring-something`) and in the linked-and-proxified-group file (where the armature object `Spring-something-proxy` is named after the group).
- Added a help button to the regular expression input so that non-developers can look up what a "regular expression" is.
- Fixed a problem with asymmetrical rigs (e.g. where `bone_L` exists but `bone_R` does not).
