### PR TITLE
Bugfixes & performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Pose Thumbnails Changelog
+
+This file logs the changes that are actually interesting to users (new features,
+changed functionality, fixed bugs). For other changes, see the Git history.
+
+
+## Version 1.0
+
+- First release that includes this changelog. For older history, see the Git log.

--- a/__init__.py
+++ b/__init__.py
@@ -20,11 +20,10 @@
 bl_info = {
     'name': 'Pose Library Thumbnails',
     'author': 'Jasper van Nieuwenhuizen (jasperge) & Sybren A. Stüvel (dr_sybren)',
-    'version': (0, 2, 3),
+    'version': (1, 0, 0),
     'blender': (2, 7, 8),
     'location': 'Properties > Armature > Pose Library',
     'description': 'Add thumbnails for the poses of a pose Library',
-    'warning': 'wip',
     'wiki_url': 'https://github.com/jasperges/pose_thumbnails/blob/master/README.md',
     'tracker_url': 'https://github.com/jasperges/pose_thumbnails/issues',
     'support': 'COMMUNITY',

--- a/pose_thumbnails.py
+++ b/pose_thumbnails.py
@@ -271,6 +271,7 @@ def set_pose(pose_a):
                 pose_bone.matrix_basis = pose_a_value
             else:
                 pose_bone[prop] = pose_a_value
+    auto_keyframe(pose_a.keys())
 
 
 def mix_to_pose(pose_a, pose_b, factor):

--- a/pose_thumbnails.py
+++ b/pose_thumbnails.py
@@ -144,7 +144,11 @@ def get_current_pose(*, flipped=False) -> dict:
     for target_pb in pose_bones:
         if flipped:
             name = flip.name(target_pb.name)
-            source_pb = armature.pose.bones[name]
+            try:
+                source_pb = arm_ob.pose.bones[name]
+            except KeyError:
+                # This bone doesn't have a flipped version, so just ignore it.
+                continue
             store_bone(target_pb, flip.matrix(source_pb.matrix_basis))
         else:
             store_bone(target_pb, target_pb.matrix_basis.copy())

--- a/pose_thumbnails.py
+++ b/pose_thumbnails.py
@@ -164,7 +164,7 @@ def get_current_pose(*, flipped=False) -> dict:
     return pose
 
 
-def bones_in_poselib(armature_ob) -> typing.List[bpy.types.PoseBone]:
+def bones_in_poselib(armature_ob: bpy.types.Object) -> typing.List[bpy.types.PoseBone]:
     """Determine bones used in current pose library."""
 
     bone_names = set()
@@ -216,9 +216,9 @@ def flip_selection():
             pass  # this happens when a bone exists only on one side
 
 
-def select_all_pose_bones(armature, select=True):
+def select_all_pose_bones(armature_ob: bpy.types.Object, select=True):
     """Select all the pose bones of the armature."""
-    for pose_bone in armature.pose.bones:
+    for pose_bone in armature_ob.pose.bones:
         pose_bone.bone.select = select
 
 

--- a/pose_thumbnails.py
+++ b/pose_thumbnails.py
@@ -216,10 +216,10 @@ def flip_selection():
             pass  # this happens when a bone exists only on one side
 
 
-def select_all_pose_bones(armature, deselect=False):
+def select_all_pose_bones(armature, select=True):
     """Select all the pose bones of the armature."""
     for pose_bone in armature.pose.bones:
-        pose_bone.bone.select = not deselect
+        pose_bone.bone.select = select
 
 
 def auto_keyframe():
@@ -242,7 +242,7 @@ def auto_keyframe():
     else:
         bpy.ops.anim.keyframe_insert_menu(type='WholeCharacterSelected')
     if not selected_pose_bones:
-        select_all_pose_bones(bpy.context.object, deselect=True)
+        select_all_pose_bones(bpy.context.object, select=False)
 
 
 def set_pose(pose_a):

--- a/pose_thumbnails.py
+++ b/pose_thumbnails.py
@@ -645,6 +645,11 @@ class PoselibThumbnailsOptions(bpy.types.PropertyGroup):
         description='Apply the pose mirrored over the YZ-plane',
         default=False,
         update=on_flipped_updated,
+        # This option shouldn't be saved, because the on_flipped_update()
+        # dumbly flips the pixels of the images. It assumes that the loaded
+        # images are consistent with this `flipped` property, whereas Blender
+        # will start up with the images loaded as on-disk (i.e. flipped=False).
+        options={'SKIP_SAVE'},
     )
 
 


### PR DESCRIPTION
Hey Jasper,

Fix:

- Fixed exception when applying a flipped pose while a bone didn't have an opposite (so when `bone_L` is in the pose library, but `bone_R` doesn't exist at all). Now such bones are simply ignored.

Improved:

- Only use bones in pose library for auto-keying. Previously all bones were keyed. For example, this resulted in keys on the face while applying a hand pose. Also, the number of keyed bones in the simplified Spring rig I test with was reduced from 1944 to 81.
- Only auto-key when applying the pose. Previously keys were also created while determining the start/end pose of a mix, and while mixing.

You can imagine that this improves the speed quite a bit.

On the subject of new versions: would you consider releasing version 1.0 and then having a CHANGELOG.md file in which we describe end-user-visible changes since then?

Update: I pushed a bump to 1.0 and a simple CHANGELOG.md file to my branch, which Github automagically merged into this pull request. Not really my intention, but I think it's good to release 1.0 anyway.

Cheers,
Sybren
