### PR TITLE
Improved tooltips, sanitized name, and synchronizing 2.8 fixes

### DIFF
--- a/pose_thumbnails/cache.py
+++ b/pose_thumbnails/cache.py
@@ -36,7 +36,10 @@ def pyside_cache(propname):
 
 
 def lru_cache_1arg(wrapped):
-    """Decorator, caches return value as long as the 1st arg doesn't change."""
+    """Decorator, caches return value as long as the 1st arg doesn't change.
+
+    The 1st arg MUST be a DNA datablock (e.g. have an as_pointer() function).
+    """
 
     cached_value = ...
     cached_arg = ...
@@ -50,7 +53,7 @@ def lru_cache_1arg(wrapped):
     def wrapper(*args, **kwargs):
         nonlocal cached_value, cached_arg
 
-        if cached_value is not ... and len(args) and args[0] == cached_arg:
+        if cached_value is not ... and len(args) and args[0].as_pointer() == cached_arg:
             return cached_value
 
         try:
@@ -61,7 +64,7 @@ def lru_cache_1arg(wrapped):
 
         if len(args):
             cached_value = result
-            cached_arg = args[0]
+            cached_arg = args[0].as_pointer()
         else:
             cache_clear()
 

--- a/pose_thumbnails/core.py
+++ b/pose_thumbnails/core.py
@@ -525,7 +525,9 @@ class POSELIB_OT_mix_pose(bpy.types.Operator):
         :param context:
         """
         POSELIB_OT_mix_pose.is_running = None
-        context.area.tag_redraw()
+
+        if context is not None:
+            context.area.tag_redraw()
 
     def apply_and_finish(self):
         """Apply the currently mixed pose and finish running the operator."""
@@ -546,6 +548,11 @@ class POSELIB_OT_mix_pose(bpy.types.Operator):
         return {'FINISHED'}
 
     def modal(self, context, event):
+        if self._target_state == 'ABORTED':
+            # Assumes the code setting this state already performed cleanup.
+            logger.debug('Aborting modal application')
+            return {'FINISHED'}
+
         if ((event.type == 'LEFTMOUSE' and event.value == 'CLICK')
                 or event.type == 'RET' or self._target_state == 'FINISHED'):
             logger.debug('Finishing modal application')


### PR DESCRIPTION
- Adds the `poselib.library_name_sanitize` operator, which somewhat intelligently takes the active post library name and updates to ensure it appears in the library dropdown (screenshot below)
- Improves tooltips to be more verbose and matching the default user preferences
- Synchronizing some changes from the forked 2.8 repo (https://github.com/jasperges/pose-thumbnails/commit/cedcbdfec7c9ccb88e055ef9c24e5ec528664231)

![sanitize library name button](https://user-images.githubusercontent.com/2958461/46589516-51ad5380-ca78-11e8-810b-b9839c7d3bbd.png)
